### PR TITLE
Migrate modules to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["nlp", "chinese", "segmenation"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/messense/jieba-rs"
+edition = '2018'
 
 [dependencies]
 smallvec = "0.6"

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ Add it to your ``Cargo.toml``:
 jieba-rs = "0.2"
 ```
 
-Add ``extern crate jieba_rs`` to your crate root and your're good to go!
+then you are good to go. If you are using Rust 2015 you have to ``extern crate jieba_rs`` to your crate root as well. 
 
 ## Example
 
 ```rust
-extern crate jieba_rs;
-
 use jieba_rs::Jieba;
 
 fn main() {

--- a/examples/weicheng/Cargo.toml
+++ b/examples/weicheng/Cargo.toml
@@ -2,6 +2,7 @@
 name = "weicheng"
 version = "0.1.0"
 authors = ["messense <messense@icloud.com>"]
+edition = "2018"
 
 [dependencies]
 jieba-rs = { path = "../.." }

--- a/examples/weicheng/src/main.rs
+++ b/examples/weicheng/src/main.rs
@@ -1,5 +1,3 @@
-extern crate jieba_rs;
-
 use std::time;
 use jieba_rs::Jieba;
 

--- a/src/hmm.rs
+++ b/src/hmm.rs
@@ -1,9 +1,11 @@
+use lazy_static::lazy_static;
+
 use std::cmp::Ordering;
 
 use phf;
 use regex::Regex;
 
-use {SplitCaptures};
+use crate::SplitCaptures;
 
 lazy_static! {
     static ref RE_HAN: Regex = Regex::new(r"([\u{4E00}-\u{9FD5}]+)").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 //! ## Example
 //!
 //! ```rust
-//! extern crate jieba_rs;
-//!
 //! use jieba_rs::Jieba;
 //!
 //! fn main() {
@@ -25,12 +23,8 @@
 //! }
 //! ```
 //!
-extern crate smallvec;
-extern crate regex;
-#[macro_use]
-extern crate lazy_static;
-extern crate phf;
-extern crate hashbrown;
+
+use lazy_static::lazy_static;
 
 use std::io::{self, BufRead, BufReader};
 use std::collections::BTreeMap;


### PR DESCRIPTION
With Rust 2018 released for almost 6 months, it should be stable to migrate to Rust 2018. This pull request is focus on the module by removing the `extern crate`

https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html