### PR TITLE
Optimize HMM implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,7 @@ impl Jieba {
                     if buf_indices.len() == 1 {
                         words.push(word);
                     } else if !self.dict.get(word).map(|x| x.0 > 0).unwrap_or(false) {
-                        words.extend(hmm::cut(word));
+                        hmm::cut(word, words);
                     } else {
                         let mut word_indices = word.char_indices().map(|x| x.0).peekable();
                         while let Some(byte_start) = word_indices.next() {
@@ -504,7 +504,7 @@ impl Jieba {
             if buf_indices.len() == 1 {
                 words.push(word);
             } else if !self.dict.get(word).map(|x| x.0 > 0).unwrap_or(false) {
-                words.extend(hmm::cut(word));
+                hmm::cut(word, words);
             } else {
                 let mut word_indices = word.char_indices().map(|x| x.0).peekable();
                 while let Some(byte_start) = word_indices.next() {


### PR DESCRIPTION
* Using one dimensional allocation and calculated index for access
* Pass in words as ref to reduce memory allocation

performance improvement by passing in words
```
jieba cut with hmm      time:   [11.255 us 11.298 us 11.346 us]
                        change: [-10.837% -9.8714% -8.9555%] (p = 0.00 < 0.05)
  1 Optimize HMM implementation
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
```


performance improvement with one dimensional allocation
```
jieba cut with hmm      time:   [10.097 us 10.297 us 10.523 us]
                        change: [-10.952% -9.8538% -8.4454%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) high mild
  11 (11.00%) high severe
```