### PR TITLE
Integrate cedar wtih jieba

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,14 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cedarwood"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +277,7 @@ dependencies = [
 name = "jieba-rs"
 version = "0.4.8"
 dependencies = [
+ "cedarwood 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -753,6 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum c_fixed_string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe6833b1e1b632d1a4c167aa8dc2a78a774bd78e14bc14579505d209327b47cf"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
+"checksum cedarwood 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81d5bcd567a824cb0c08518d67f892f1aed0e434b37717ca3c110b6fc4231564"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ regex = "1.0"
 lazy_static = "1.0"
 phf = "0.7"
 hashbrown = "0.5.0"
+cedarwood = "0.4"
 
 [build-dependencies]
 phf_codegen = "0.7"


### PR DESCRIPTION
```
     Running target/release/deps/jieba_benchmark-71699137a294448b
Gnuplot not found, disabling plotting
jieba cut/no hmm        time:   [5.7015 us 5.7115 us 5.7222 us]
                        thrpt:  [20.000 MiB/s 20.037 MiB/s 20.072 MiB/s]
                 change:
                        time:   [-9.8841% -8.6007% -6.7179%] (p = 0.00 < 0.05)
                        thrpt:  [+7.2017% +9.4101% +10.968%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
jieba cut/with hmm      time:   [8.0561 us 8.0856 us 8.1233 us]
                        thrpt:  [14.088 MiB/s 14.154 MiB/s 14.205 MiB/s]
                 change:
                        time:   [-1.7646% -0.8881% +0.1019%] (p = 0.07 > 0.05)
                        thrpt:  [-0.1018% +0.8960% +1.7963%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
jieba cut/cut_all       time:   [3.9688 us 3.9902 us 4.0258 us]
                        thrpt:  [28.427 MiB/s 28.680 MiB/s 28.835 MiB/s]
                 change:
                        time:   [-12.485% -11.873% -11.189%] (p = 0.00 < 0.05)
                        thrpt:  [+12.598% +13.472% +14.266%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
jieba cut/cut_for_search
                        time:   [9.4384 us 9.4607 us 9.4839 us]
                        thrpt:  [12.067 MiB/s 12.097 MiB/s 12.125 MiB/s]
                 change:
                        time:   [+0.2530% +1.1300% +2.0880%] (p = 0.01 < 0.05)
                        thrpt:  [-2.0453% -1.1174% -0.2524%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```

master
```
➜  jieba-rs git:(master) ./target/release/weicheng
3779ms
```

cedar
```
➜  jieba-rs git:(cedar) ./target/release/weicheng
3672ms
```