### PR TITLE
Optimize StaticSparseDAG

### DIFF
--- a/src/sparse_dag.rs
+++ b/src/sparse_dag.rs
@@ -33,9 +33,11 @@ impl<'a> Iterator for EdgeIter<'a> {
 
 impl StaticSparseDAG {
     pub(crate) fn with_size_hint(hint: usize) -> Self {
+        let mut start_pos = HashMap::default();
+        start_pos.reserve(hint);
         StaticSparseDAG {
             array: Vec::with_capacity(hint * 5),
-            start_pos: HashMap::default(),
+            start_pos,
             size_hint_for_iterator: 0,
             curr_insertion_len: 0,
         }


### PR DESCRIPTION
```
     Running target/release/deps/jieba_benchmark-c42bc917444554a4
jieba cut/no hmm        time:   [4.7455 us 4.7787 us 4.8193 us]
                        thrpt:  [23.746 MiB/s 23.948 MiB/s 24.116 MiB/s]
                 change:
                        time:   [-7.5594% -6.5206% -5.3792%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6850% +6.9754% +8.1776%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe
jieba cut/with hmm      time:   [6.8511 us 6.8875 us 6.9327 us]
                        thrpt:  [16.507 MiB/s 16.616 MiB/s 16.704 MiB/s]
                 change:
                        time:   [-6.0804% -5.4246% -4.8120%] (p = 0.00 < 0.05)
                        thrpt:  [+5.0552% +5.7358% +6.4740%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
jieba cut/cut_all       time:   [3.2706 us 3.3061 us 3.3662 us]
                        thrpt:  [33.997 MiB/s 34.615 MiB/s 34.991 MiB/s]
                 change:
                        time:   [-11.900% -10.922% -9.8100%] (p = 0.00 < 0.05)
                        thrpt:  [+10.877% +12.262% +13.508%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe
jieba cut/cut_for_search
                        time:   [7.9433 us 7.9738 us 8.0148 us]
                        thrpt:  [14.279 MiB/s 14.352 MiB/s 14.407 MiB/s]
                 change:
                        time:   [-6.7462% -5.8325% -5.0203%] (p = 0.00 < 0.05)
                        thrpt:  [+5.2857% +6.1938% +7.2342%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

jieba tokenize/default mode
                        time:   [7.0391 us 7.0736 us 7.1136 us]
                        thrpt:  [16.088 MiB/s 16.179 MiB/s 16.258 MiB/s]
                 change:
                        time:   [-6.8622% -6.1621% -5.5252%] (p = 0.00 < 0.05)
                        thrpt:  [+5.8483% +6.5668% +7.3677%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
jieba tokenize/search mode
                        time:   [7.4325 us 7.4871 us 7.5621 us]
                        thrpt:  [15.133 MiB/s 15.285 MiB/s 15.397 MiB/s]
                 change:
                        time:   [-6.1393% -5.0978% -3.9786%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1435% +5.3716% +6.5409%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

jieba/tag               time:   [7.3073 us 7.3411 us 7.3822 us]
                        thrpt:  [15.502 MiB/s 15.589 MiB/s 15.661 MiB/s]
                 change:
                        time:   [-7.6387% -6.3762% -5.1378%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4160% +6.8105% +8.2705%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

jieba extract keywords/tfidf
                        time:   [8.2522 us 8.2914 us 8.3384 us]
                        thrpt:  [13.725 MiB/s 13.802 MiB/s 13.868 MiB/s]
                 change:
                        time:   [-7.4338% -5.8604% -4.4853%] (p = 0.00 < 0.05)
                        thrpt:  [+4.6959% +6.2252% +8.0307%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe
jieba extract keywords/textrank
                        time:   [18.681 us 18.763 us 18.864 us]
                        thrpt:  [6.0667 MiB/s 6.0992 MiB/s 6.1262 MiB/s]
                 change:
                        time:   [-3.0901% -1.9062% -0.8743%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8820% +1.9433% +3.1887%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```

cc @MnO2 