### PR TITLE
Break lifetime entanglement of TextExtract, TFIDF and Jieba

### DIFF
--- a/benches/jieba_benchmark.rs
+++ b/benches/jieba_benchmark.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 
 use criterion::{black_box, Criterion, Throughput};
-use jieba_rs::{Jieba, KeywordExtract, TextRank, TokenizeMode, TFIDF};
+use jieba_rs::{Jieba, KeywordExtract, TextRank, TokenizeMode, TfIdf};
 use lazy_static::lazy_static;
 
 #[cfg(unix)]
@@ -11,8 +11,8 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 lazy_static! {
     static ref JIEBA: Jieba = Jieba::new();
-    static ref TFIDF_EXTRACTOR: TFIDF<'static> = TFIDF::new_with_jieba(&JIEBA);
-    static ref TEXTRANK_EXTRACTOR: TextRank<'static> = TextRank::new_with_jieba(&JIEBA);
+    static ref TFIDF_EXTRACTOR: TfIdf = TfIdf::default();
+    static ref TEXTRANK_EXTRACTOR: TextRank = TextRank::default();
 }
 static SENTENCE: &str = "我是拖拉机学院手扶拖拉机专业的。不用多久，我就会升职加薪，当上CEO，走上人生巅峰。";
 
@@ -55,10 +55,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("keywords");
     group.throughput(Throughput::Bytes(SENTENCE.len() as u64));
     group.bench_function("tfidf", |b| {
-        b.iter(|| TFIDF_EXTRACTOR.extract_tags(black_box(SENTENCE), 3, Vec::new()))
+        b.iter(|| TFIDF_EXTRACTOR.extract_keywords(&JIEBA, black_box(SENTENCE), 3, Vec::new()))
     });
     group.bench_function("textrank", |b| {
-        b.iter(|| TEXTRANK_EXTRACTOR.extract_tags(black_box(SENTENCE), 3, Vec::new()))
+        b.iter(|| TEXTRANK_EXTRACTOR.extract_keywords(&JIEBA, black_box(SENTENCE), 3, Vec::new()))
     });
     group.finish();
 }

--- a/benches/jieba_benchmark.rs
+++ b/benches/jieba_benchmark.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 
 use criterion::{black_box, Criterion, Throughput};
-use jieba_rs::{Jieba, KeywordExtract, TextRank, TokenizeMode, TfIdf};
+use jieba_rs::{Jieba, KeywordExtract, TextRank, TfIdf, TokenizeMode};
 use lazy_static::lazy_static;
 
 #[cfg(unix)]

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 fn main() {
     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("hmm_prob.rs");
     let hmm_file = File::open("src/data/hmm.model").expect("cannot open hmm.model");
-    let mut file = BufWriter::new(File::create(&path).unwrap());
+    let mut file = BufWriter::new(File::create(path).unwrap());
     let reader = BufReader::new(hmm_file);
     let mut lines = reader.lines().map(|x| x.unwrap()).skip_while(|x| x.starts_with('#'));
     let prob_start = lines.next().unwrap();

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,5 +1,5 @@
 use c_fixed_string::CFixedStr;
-use jieba_rs::{Jieba, KeywordExtract, TFIDFState, TextRank, TFIDF};
+use jieba_rs::{Jieba, KeywordExtract, TextRank, TFIDF};
 use std::boxed::Box;
 use std::os::raw::c_char;
 use std::{mem, ptr};

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,5 +1,5 @@
 use c_fixed_string::CFixedStr;
-use jieba_rs::{Jieba, KeywordExtract, TextRank, TFIDF};
+use jieba_rs::{Jieba, KeywordExtract, TFIDFState, TextRank, TFIDF};
 use std::boxed::Box;
 use std::os::raw::c_char;
 use std::{mem, ptr};

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -32,7 +32,7 @@ pub struct Keyword {
     pub weight: f64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KeywordExtractConfig {
     stop_words: BTreeSet<String>,
     min_keyword_length: usize,

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -9,7 +9,7 @@ pub mod textrank;
 pub mod tfidf;
 
 lazy_static! {
-    pub static ref STOP_WORDS: BTreeSet<String> = {
+    pub static ref DEFAULT_STOP_WORDS: BTreeSet<String> = {
         let mut set = BTreeSet::new();
         let words = [
             "the", "of", "is", "and", "to", "in", "that", "we", "for", "an", "are", "by", "be", "as", "on", "with",
@@ -26,7 +26,7 @@ lazy_static! {
 }
 
 /// Keyword with weight
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Keyword {
     pub keyword: String,
     pub weight: f64,

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -32,6 +32,79 @@ pub struct Keyword {
     pub weight: f64,
 }
 
+#[derive(Debug)]
+pub struct KeywordExtractConfig {
+    stop_words: BTreeSet<String>,
+    min_keyword_length: usize,
+    use_hmm: bool,
+}
+
+impl KeywordExtractConfig {
+    /// Creates a KeywordExtractConfig state that contains filter criteria as
+    /// well as segmentation configuration for use by keyword extraction
+    /// implementations.
+    pub fn new(stop_words: BTreeSet<String>, min_keyword_length: usize, use_hmm: bool) -> Self {
+        KeywordExtractConfig {
+            stop_words,
+            min_keyword_length,
+            use_hmm,
+        }
+    }
+
+    /// Add a new stop word.
+    pub fn add_stop_word(&mut self, word: String) -> bool {
+        self.stop_words.insert(word)
+    }
+
+    /// Remove an existing stop word.
+    pub fn remove_stop_word(&mut self, word: &str) -> bool {
+        self.stop_words.remove(word)
+    }
+
+    /// Replace all stop words with new stop words set.
+    pub fn set_stop_words(&mut self, stop_words: BTreeSet<String>) {
+        self.stop_words = stop_words
+    }
+
+    /// Get current set of stop words.
+    pub fn get_stop_words(&self) -> &BTreeSet<String> {
+        &self.stop_words
+    }
+
+    /// True if hmm is used during segmentation in `extract_tags`.
+    pub fn get_use_hmm(&self) -> bool {
+        self.use_hmm
+    }
+
+    /// Sets whether or not to use hmm during segmentation in `extract_tags`.
+    pub fn set_use_hmm(&mut self, use_hmm: bool) {
+        self.use_hmm = use_hmm
+    }
+
+    /// Gets the minimum number of Unicode Scalar Values required per keyword.
+    pub fn get_min_keyword_length(&self) -> usize {
+        self.min_keyword_length
+    }
+
+    /// Sets the minimum number of Unicode Scalar Values required per keyword.
+    ///
+    /// The default is 2. There is likely not much reason to change this.
+    pub fn set_min_keyword_length(&mut self, min_keyword_length: usize) {
+        self.min_keyword_length = min_keyword_length
+    }
+
+    #[inline]
+    pub fn filter(&self, s: &str) -> bool {
+        s.chars().count() >= self.min_keyword_length && !self.stop_words.contains(&s.to_lowercase())
+    }
+}
+
+impl Default for KeywordExtractConfig {
+    fn default() -> Self {
+        KeywordExtractConfig::new(DEFAULT_STOP_WORDS.clone(), 2, false)
+    }
+}
+
 pub trait KeywordExtract {
     fn extract_tags(&self, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword>;
 }

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -94,7 +94,7 @@ impl KeywordExtractConfig {
     }
 
     #[inline]
-    pub fn filter(&self, s: &str) -> bool {
+    pub(crate) fn filter(&self, s: &str) -> bool {
         s.chars().count() >= self.min_keyword_length && !self.stop_words.contains(&s.to_lowercase())
     }
 }

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -1,6 +1,8 @@
 use lazy_static::lazy_static;
 use std::collections::BTreeSet;
 
+use crate::Jieba;
+
 #[cfg(feature = "textrank")]
 pub mod textrank;
 #[cfg(feature = "tfidf")]
@@ -32,4 +34,9 @@ pub struct Keyword {
 
 pub trait KeywordExtract {
     fn extract_tags(&self, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword>;
+}
+
+/// Version of KeywordExtract trait that requires a Jieba instance on invocation.
+pub trait JiebaKeywordExtract {
+    fn extract_tags(&self, jieba: &Jieba, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword>;
 }

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -105,11 +105,7 @@ impl Default for KeywordExtractConfig {
     }
 }
 
+/// Extracts keywords from a given sentence with the Jieba instance.
 pub trait KeywordExtract {
-    fn extract_tags(&self, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword>;
-}
-
-/// Version of KeywordExtract trait that requires a Jieba instance on invocation.
-pub trait JiebaKeywordExtract {
-    fn extract_tags(&self, jieba: &Jieba, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword>;
+    fn extract_keywords(&self, jieba: &Jieba, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword>;
 }

--- a/src/keywords/textrank.rs
+++ b/src/keywords/textrank.rs
@@ -279,7 +279,7 @@ mod tests {
         );
         assert_eq!(
             top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
-            vec!["吉林", "欧亚", "置业", "实现", "收入", "增资"]
+            vec!["吉林", "欧亚", "置业", "实现", "收入", "子公司"]
         );
 
         top_k = keyword_extractor.extract_tags(

--- a/src/keywords/textrank.rs
+++ b/src/keywords/textrank.rs
@@ -86,10 +86,11 @@ impl UnboundTextRank {
     /// during segmentation.
     /// ```
     ///    use std::collections::BTreeSet;
+    ///    use jieba_rs::{UnboundTextRank, KeywordExtractConfig};
     ///
     ///    let stop_words : BTreeSet<String> =
     ///        BTreeSet::from(["a", "the", "of"].map(|s| s.to_string()));
-    ///    jieba_rs::UnboundTextRank::new(
+    ///    UnboundTextRank::new(
     ///        5,
     ///        KeywordExtractConfig::default());
     /// ```

--- a/src/keywords/tfidf.rs
+++ b/src/keywords/tfidf.rs
@@ -50,19 +50,23 @@ impl UnboundTfidf {
     ///
     /// New instance with custom idf dictionary.
     /// ```
+    ///    use jieba_rs::{UnboundTfidf, KeywordExtractConfig};
+    ///
     ///    let mut sample_idf = "劳动防护 13.900677652\n\
     ///        生化学 13.900677652\n";
-    ///    jieba_rs::UnboundTfidf::new(
+    ///    UnboundTfidf::new(
     ///        Some(&mut sample_idf.as_bytes()),
-    ///        jieba_rs::KeywordExtractConfig::default());
+    ///        KeywordExtractConfig::default());
     /// ```
     ///
     /// New instance with module default stop words and no initial IDF
     /// dictionary. Dictionary should be loaded later with `load_dict()` calls.
     /// ```
-    ///    jieba_rs::UnboundTfidf::new(
+    ///    use jieba_rs::{UnboundTfidf, KeywordExtractConfig};
+    ///
+    ///    UnboundTfidf::new(
     ///        None::<&mut std::io::Empty>,
-    ///        jieba_rs::KeywordExtractConfig::default());
+    ///        KeywordExtractConfig::default());
     /// ```
     pub fn new(opt_dict: Option<&mut impl BufRead>, config: KeywordExtractConfig) -> Self {
         let mut instance = UnboundTfidf {

--- a/src/keywords/tfidf.rs
+++ b/src/keywords/tfidf.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufRead, BufReader};
 
 use ordered_float::OrderedFloat;
 
-use super::{JiebaKeywordExtract, Keyword, KeywordExtract, STOP_WORDS};
+use super::{JiebaKeywordExtract, Keyword, KeywordExtract, DEFAULT_STOP_WORDS};
 use crate::FxHashMap as HashMap;
 use crate::Jieba;
 
@@ -32,18 +32,62 @@ impl<'a> PartialOrd for HeapNode<'a> {
 ///
 /// Require `tfidf` feature to be enabled
 #[derive(Debug)]
-pub struct UnboundTFIDF {
+pub struct UnboundTfidf {
     idf_dict: HashMap<String, f64>,
     median_idf: f64,
     stop_words: BTreeSet<String>,
+    min_keyword_length: usize,
+    use_hmm: bool,
 }
 
-impl UnboundTFIDF {
-    pub fn new<R: BufRead>(opt_dict: Option<&mut R>, stop_words: BTreeSet<String>) -> Self {
-        let mut instance = UnboundTFIDF {
+/// Implementation of JiebaKeywordExtract using a TFIDF dictionary.
+///
+/// This takes the segments produced by Jieba and attempts to extract keywords.
+/// Segments are filtered for stopwords and short terms. They are then matched
+/// against a loaded dictionary to calculate TFIDF scores.
+impl UnboundTfidf {
+    /// Creates an UnboundTfidf.
+    ///
+    /// # Examples
+    ///
+    /// New instance with custom stop words and idf dictionary. Also uses hmm
+    /// for unknown words during segmentation and allows keywords of length 1.
+    /// ```
+    ///    use std::collections::BTreeSet;
+    ///
+    ///    let stop_words : BTreeSet<String> =
+    ///        BTreeSet::from(["a", "the", "of"].map(|s| s.to_string()));
+    ///    let mut sample_idf = "劳动防护 13.900677652\n\
+    ///        生化学 13.900677652\n";
+    ///    jieba_rs::UnboundTfidf::new(
+    ///        Some(&mut sample_idf.as_bytes()),
+    ///        stop_words,
+    ///        1,
+    ///        true);
+    /// ```
+    ///
+    /// New instance with module default stop words and no initial IDF
+    /// dictionary. Dictionary should be loaded later with `load_dict()` calls.
+    /// No hmm and more standard minimal of length 2 keywords.
+    /// ```
+    ///    jieba_rs::UnboundTfidf::new(
+    ///        None::<&mut std::io::Empty>,
+    ///        jieba_rs::DEFAULT_STOP_WORDS.clone(),
+    ///        2,
+    ///        false);
+    /// ```
+    pub fn new(
+        opt_dict: Option<&mut impl BufRead>,
+        stop_words: BTreeSet<String>,
+        min_keyword_length: usize,
+        use_hmm: bool,
+    ) -> Self {
+        let mut instance = UnboundTfidf {
             idf_dict: HashMap::default(),
             median_idf: 0.0,
-            stop_words: stop_words,
+            stop_words,
+            min_keyword_length,
+            use_hmm,
         };
         if let Some(dict) = opt_dict {
             instance.load_dict(dict).unwrap();
@@ -51,7 +95,40 @@ impl UnboundTFIDF {
         instance
     }
 
-    pub fn load_dict<R: BufRead>(&mut self, dict: &mut R) -> io::Result<()> {
+    /// Merges entires from `dict` into the `idf_dict`.
+    ///
+    /// ```
+    ///    use jieba_rs::{Jieba, JiebaKeywordExtract, Keyword,
+    ///        UnboundTfidf, DEFAULT_STOP_WORDS};
+    ///
+    ///    let jieba = Jieba::default();
+    ///    let mut init_idf = "生化学 13.900677652\n";
+    ///
+    ///    let mut tfidf = UnboundTfidf::new(
+    ///        Some(&mut init_idf.as_bytes()),
+    ///        DEFAULT_STOP_WORDS.clone(),
+    ///        true);
+    ///    let top_k = tfidf.extract_tags(&jieba, "生化学很難", 3, vec![]);
+    ///    assert_eq!(
+    ///        top_k,
+    ///        vec![
+    ///            Keyword { keyword: "很難".to_string(), weight: 6.950338826 },
+    ///            Keyword { keyword: "生化学".to_string(), weight: 6.950338826 }
+    ///        ]
+    ///    );
+    ///
+    ///    let mut init_idf = "很難 99.123456789\n";
+    ///    tfidf.load_dict(&mut init_idf.as_bytes());
+    ///    let top_k = tfidf.extract_tags(&jieba, "生化学很難", 3, vec![]);
+    ///    assert_eq!(
+    ///        top_k,
+    ///        vec![
+    ///            Keyword { keyword: "很難".to_string(), weight: 49.5617283945 },
+    ///            Keyword { keyword: "生化学".to_string(), weight: 6.950338826 }
+    ///        ]
+    ///    );
+    /// ```
+    pub fn load_dict(&mut self, dict: &mut impl BufRead) -> io::Result<()> {
         let mut buf = String::new();
         let mut idf_heap = BinaryHeap::new();
         while dict.read_line(&mut buf)? > 0 {
@@ -79,45 +156,66 @@ impl UnboundTFIDF {
         Ok(())
     }
 
-    /// Add a new stop word
+    /// Add a new stop word.
     pub fn add_stop_word(&mut self, word: String) -> bool {
         self.stop_words.insert(word)
     }
 
-    /// Remove an existing stop word
+    /// Remove an existing stop word.
     pub fn remove_stop_word(&mut self, word: &str) -> bool {
         self.stop_words.remove(word)
     }
 
-    /// Replace all stop words with new stop words set
+    /// Replace all stop words with new stop words set.
     pub fn set_stop_words(&mut self, stop_words: BTreeSet<String>) {
         self.stop_words = stop_words
     }
 
+    /// Get current set of stop words.
+    pub fn get_stop_words(&self) -> &BTreeSet<String> {
+        &self.stop_words
+    }
+
+    /// True if hmm is used during segmentation in `extract_tags`.
+    pub fn get_use_hmm(&self) -> bool {
+        self.use_hmm
+    }
+
+    /// Sets whether or not to use hmm during segmentation in `extract_tags`.
+    pub fn set_use_hmm(&mut self, use_hmm: bool) {
+        self.use_hmm = use_hmm
+    }
+
+    /// Gets the minimum number of Unicode Scalar Values required per keyword.
+    pub fn get_min_keyword_length(&self) -> usize {
+        self.min_keyword_length
+    }
+
+    /// Sets the minimum number of Unicode Scalar Values required per keyword.
+    ///
+    /// The default is 2. There is likely not much reason to change this.
+    pub fn set_min_keyword_length(&mut self, min_keyword_length: usize) {
+        self.min_keyword_length = min_keyword_length
+    }
+
     #[inline]
     fn filter(&self, s: &str) -> bool {
-        if s.chars().count() < 2 {
-            return false;
-        }
-
-        if self.stop_words.contains(&s.to_lowercase()) {
-            return false;
-        }
-
-        true
+        s.chars().count() >= self.min_keyword_length && !self.stop_words.contains(&s.to_lowercase())
     }
 }
 
-impl Default for UnboundTFIDF {
+impl Default for UnboundTfidf {
+    /// Creates UnboundTfidf with DEFAULT_STOP_WORDS, the default TFIDF dictionary,
+    /// 2 Unicode Scalar Value minimum for keywords, and no hmm in segmentation.
     fn default() -> Self {
         let mut default_dict = BufReader::new(DEFAULT_IDF.as_bytes());
-        UnboundTFIDF::new(Some(&mut default_dict), STOP_WORDS.clone())
+        UnboundTfidf::new(Some(&mut default_dict), DEFAULT_STOP_WORDS.clone(), 2, false)
     }
 }
 
-impl JiebaKeywordExtract for UnboundTFIDF {
+impl JiebaKeywordExtract for UnboundTfidf {
     fn extract_tags(&self, jieba: &Jieba, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword> {
-        let tags = jieba.tag(sentence, false);
+        let tags = jieba.tag(sentence, self.use_hmm);
         let mut allowed_pos_set = BTreeSet::new();
 
         for s in allowed_pos {
@@ -173,7 +271,7 @@ impl JiebaKeywordExtract for UnboundTFIDF {
 #[derive(Debug)]
 pub struct TFIDF<'a> {
     jieba: &'a Jieba,
-    unbound_tfidf: UnboundTFIDF,
+    unbound_tfidf: UnboundTfidf,
 }
 
 impl<'a> TFIDF<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,13 @@
 //! ```rust
 //! # #[cfg(feature = "tfidf")] {
 //! use jieba_rs::Jieba;
-//! use jieba_rs::{TFIDF, KeywordExtract};
+//! use jieba_rs::{TfIdf, KeywordExtract};
 //!
 //! fn main() {
 //!     let jieba = Jieba::new();
-//!     let keyword_extractor = TFIDF::new_with_jieba(&jieba);
-//!     let top_k = keyword_extractor.extract_tags(
+//!     let keyword_extractor = TfIdf::default();
+//!     let top_k = keyword_extractor.extract_keywords(
+//!         &jieba,
 //!         "今天纽约的天气真好啊，京华大酒店的张尧经理吃了一只北京烤鸭。后天纽约的天气不好，昨天纽约的天气也不好，北京烤鸭真好吃",
 //!         3,
 //!         vec![],
@@ -46,8 +47,9 @@
 //!
 //! fn main() {
 //!     let jieba = Jieba::new();
-//!     let keyword_extractor = TextRank::new_with_jieba(&jieba);
-//!     let top_k = keyword_extractor.extract_tags(
+//!     let keyword_extractor = TextRank::default();
+//!     let top_k = keyword_extractor.extract_keywords(
+//!         &jieba,
 //!         "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
 //!         6,
 //!         vec![String::from("ns"), String::from("n"), String::from("vn"), String::from("v")],
@@ -82,11 +84,11 @@ pub(crate) type FxHashMap<K, V> = HashMap<K, V, fxhash::FxBuildHasher>;
 
 pub use crate::errors::Error;
 #[cfg(feature = "textrank")]
-pub use crate::keywords::textrank::{TextRank, UnboundTextRank};
+pub use crate::keywords::textrank::TextRank;
 #[cfg(feature = "tfidf")]
-pub use crate::keywords::tfidf::{UnboundTfidf, TFIDF};
+pub use crate::keywords::tfidf::TfIdf;
 #[cfg(any(feature = "tfidf", feature = "textrank"))]
-pub use crate::keywords::{JiebaKeywordExtract, Keyword, KeywordExtract, KeywordExtractConfig, DEFAULT_STOP_WORDS};
+pub use crate::keywords::{Keyword, KeywordExtract, KeywordExtractConfig, DEFAULT_STOP_WORDS};
 
 mod errors;
 mod hmm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,11 @@ pub(crate) type FxHashMap<K, V> = HashMap<K, V, fxhash::FxBuildHasher>;
 
 pub use crate::errors::Error;
 #[cfg(feature = "textrank")]
-pub use crate::keywords::textrank::TextRank;
-pub use crate::keywords::textrank::UnboundTextRank;
-pub use crate::keywords::tfidf::UnboundTfidf;
+pub use crate::keywords::textrank::{TextRank, UnboundTextRank};
 #[cfg(feature = "tfidf")]
-pub use crate::keywords::tfidf::TFIDF;
+pub use crate::keywords::tfidf::{UnboundTfidf, TFIDF};
 #[cfg(any(feature = "tfidf", feature = "textrank"))]
-pub use crate::keywords::{JiebaKeywordExtract, Keyword, KeywordExtract, DEFAULT_STOP_WORDS};
+pub use crate::keywords::{JiebaKeywordExtract, Keyword, KeywordExtract, KeywordExtractConfig, DEFAULT_STOP_WORDS};
 
 mod errors;
 mod hmm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,12 @@ pub(crate) type FxHashMap<K, V> = HashMap<K, V, fxhash::FxBuildHasher>;
 pub use crate::errors::Error;
 #[cfg(feature = "textrank")]
 pub use crate::keywords::textrank::TextRank;
+pub use crate::keywords::textrank::UnboundTextRank;
+pub use crate::keywords::tfidf::UnboundTfidf;
 #[cfg(feature = "tfidf")]
 pub use crate::keywords::tfidf::TFIDF;
 #[cfg(any(feature = "tfidf", feature = "textrank"))]
-pub use crate::keywords::{Keyword, KeywordExtract};
+pub use crate::keywords::{JiebaKeywordExtract, Keyword, KeywordExtract, DEFAULT_STOP_WORDS};
 
 mod errors;
 mod hmm;


### PR DESCRIPTION
Modify KeywordExtract to take a Jieba instance during the keyword extraction call instead of during construction.  Remove the Jieba reference and the lifetimes from struct TextRank as well as struct TFIDF.

This is desirable in situations where the extractor instance might outlive a single function call.

One specific case where this comes up is in binding from other languages where the Jieba instance may be refcounted and shared between API calls in a way that depends on the other languages's calling semantics. In these situations, it is hard to have TextRank and TFIDF be bound to the Jieba instance via Rust's understanding of scoped-based lifetimes.

Luckily, the KeywordExtract interface only uses the Jieba instance on execution of the extraction and arguably, the API should just take the Jieba instance in (or even possibly the resulting segments) to reduce coupling of the structs.  In this PR, the Jieba instance was moved from construction down to the function where it was used.

Since this is an API breaking change, the PR also cleans up the API style per This brings the API more in line with Rust conventions per

https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits

Specifically:
  * TFIDF was renamed TfIdf to follow Rust's capitalization conventions for acronyms.
  * KeywordExtract::extract_tags() was renamed to KeywordExtract::extract_keywords()
  * A KeywordExtractConfig object was created holding common code from both TextRank and TfIdf.
  * {TextExtract,TfIdf}::new() no longer encodes defaults and just the algorithm parameters as well as a KeywordExtractConfig object
   * TextExtract and TfIdf both implement the Default trait and expose a default() method with the default configuration.
   * API tests moved into doc tests further collocating code with test.

CAVEAT: In the new code, TextExtract defaults to NOT use hmm in the Jieba cutting.  In the old code TextExtract had hmm on and TFIDF had hmm had it off. This inconsistency looks like an oversight.

fixes #99 