### PR TITLE
Add doctest support into coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,13 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+        # Nighty needed for --doctests support. See https://github.com/taiki-e/cargo-llvm-cov/issues/2
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lcov --doctests --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
Moving tests to doctests caused the previous llvm-cov command to stop running them.  Adding the --doctest flag puts them back in but requires the nightly toolchain.