### PR TITLE
fix wrong visibility modifier

### DIFF
--- a/src/hmm.rs
+++ b/src/hmm.rs
@@ -77,7 +77,7 @@ fn viterbi(sentence: &str, hmm_context: &mut HmmContext) {
     let str_len = sentence.len();
     let states = [State::Begin, State::Middle, State::End, State::Single];
     #[allow(non_snake_case)]
-    let R = states.len();
+        let R = states.len();
     let C = sentence.chars().count();
     assert!(C > 1);
 
@@ -151,7 +151,7 @@ fn viterbi(sentence: &str, hmm_context: &mut HmmContext) {
 }
 
 #[allow(non_snake_case)]
-pub fn cut_internal<'a>(sentence: &'a str, words: &mut Vec<&'a str>, hmm_context: &mut HmmContext) {
+pub(crate) fn cut_internal<'a>(sentence: &'a str, words: &mut Vec<&'a str>, hmm_context: &mut HmmContext) {
     let str_len = sentence.len();
     viterbi(sentence, hmm_context);
     let mut begin = 0;

--- a/src/hmm.rs
+++ b/src/hmm.rs
@@ -77,7 +77,7 @@ fn viterbi(sentence: &str, hmm_context: &mut HmmContext) {
     let str_len = sentence.len();
     let states = [State::Begin, State::Middle, State::End, State::Single];
     #[allow(non_snake_case)]
-        let R = states.len();
+    let R = states.len();
     let C = sentence.chars().count();
     assert!(C > 1);
 


### PR DESCRIPTION
This fixes the following error when using this crate:

```
error[E0446]: crate-private type `HmmContext` in public interface
   --> /Users/zh217/.cargo/registry/src/index.crates.io-6f17d22bba15001f/jieba-rs-0.7.0/src/hmm.rs:154:1
    |
59  | pub(crate) struct HmmContext {
    | ---------------------------- `HmmContext` declared as crate-private
...
154 | pub fn cut_internal<'a>(sentence: &'a str, words: &mut Vec<&'a str>, hmm_context: &mut HmmContext) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
```