### PR TITLE
Optimize performance for large-scale parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 codspeed-criterion-compat = { workspace = true }
 rand = { workspace = true }
 wasm-bindgen-test = { workspace = true }
+rayon = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 jemallocator = "0.5.0"
@@ -59,5 +60,6 @@ ordered-float = "4.0"
 phf = "0.11"
 phf_codegen = "0.11"
 rand = "0.8"
+rayon = "1.10"
 regex = "1.0"
 wasm-bindgen-test = "0.3.0"


### PR DESCRIPTION
This PR addresses performance bottlenecks in multithreaded scenarios by refactoring how Regex objects are handled.

The crate currently uses a globally shared Regex object, which internally maintains a [cache pool](https://docs.rs/regex-automata/0.4.9/regex_automata/util/pool/struct.Pool.html). This implementation causes significant contention overhead when accessed by multiple threads simultaneously.

This PR changes Regex objects from global to thread-local storage. Each thread now compiles its own Regex upon first access and maintains an independent cache. We also add a new multithreaded benchmark to demonstrate the impact.

On a 11-core Macbook M3 Pro:
```
main:
multithreaded/multi_thread
                        time:   [118.90 µs 119.68 µs 120.63 µs]
                        thrpt:  [971.50 KiB/s 979.16 KiB/s 985.63 KiB/s]

this PR:
multithreaded/multi_thread
                        time:   [98.642 µs 99.572 µs 100.53 µs]
                        thrpt:  [1.1384 MiB/s 1.1493 MiB/s 1.1602 MiB/s]
                 change:
                        time:   [-18.014% -17.382% -16.666%] (p = 0.00 < 0.05)
                        thrpt:  [+20.000% +21.039% +21.972%]
```

On a 192-core x86_64 server:
```
main:
multithreaded/multi_thread
                        time:   [1.1241 ms 1.1523 ms 1.2042 ms]
                        thrpt:  [95.038 MiB/s 99.318 MiB/s 101.81 MiB/s]

this PR:
multithreaded/multi_thread
                        time:   [257.17 µs 258.42 µs 259.53 µs]
                        thrpt:  [440.96 MiB/s 442.85 MiB/s 445.01 MiB/s]
                 change:
                        time:   [-77.636% -77.141% -76.776%] (p = 0.00 < 0.05)
                        thrpt:  [+330.59% +337.47% +347.15%]
```

Tips: **Hide whitespace** for better review experience