### PR TITLE
optimize HmmContext initialization

### DIFF
--- a/src/hmm.rs
+++ b/src/hmm.rs
@@ -54,20 +54,11 @@ generate_hmm_data!();
 
 const MIN_FLOAT: f64 = -3.14e100;
 
+#[derive(Default)]
 pub(crate) struct HmmContext {
     v: Vec<f64>,
     prev: Vec<Option<State>>,
     best_path: Vec<State>,
-}
-
-impl HmmContext {
-    pub fn new(num_characters: usize) -> Self {
-        HmmContext {
-            v: vec![0.0; NUM_STATES * num_characters],
-            prev: vec![None; NUM_STATES * num_characters],
-            best_path: vec![State::Begin; num_characters],
-        }
-    }
 }
 
 #[allow(non_snake_case)]
@@ -220,7 +211,7 @@ pub(crate) fn cut_with_allocated_memory<'a>(sentence: &'a str, words: &mut Vec<&
 
 #[allow(non_snake_case)]
 pub fn cut<'a>(sentence: &'a str, words: &mut Vec<&'a str>) {
-    let mut hmm_context = HmmContext::new(sentence.chars().count());
+    let mut hmm_context = HmmContext::default();
 
     cut_with_allocated_memory(sentence, words, &mut hmm_context)
 }
@@ -236,7 +227,7 @@ mod tests {
 
         let sentence = "小明硕士毕业于中国科学院计算所";
 
-        let mut hmm_context = HmmContext::new(sentence.chars().count());
+        let mut hmm_context = HmmContext::default();
         viterbi(sentence, &mut hmm_context);
         assert_eq!(
             hmm_context.best_path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,7 +658,7 @@ impl Jieba {
                 let mut route = Vec::with_capacity(heuristic_capacity);
                 let mut dag = StaticSparseDAG::with_size_hint(heuristic_capacity);
 
-                let mut hmm_context = hmm::HmmContext::new(sentence.chars().count());
+                let mut hmm_context = hmm::HmmContext::default();
 
                 for state in splitter {
                     match state {


### PR DESCRIPTION
Currently, `HmmContext` is created and allocates memory during every tokenization, regardless of whether it's actually used. However, the `viterbi` function already ensures the buffer is resized to the required length before using `HmmContext`. 

https://github.com/messense/jieba-rs/blob/91d39ccd64b817d85ec0db01db01cd7d32dce6ff/src/hmm.rs#L82-L93

This PR removes the unnecessary pre-allocation in `HmmContext::new`, eliminating many redundant malloc operations and improving performance.