### PR TITLE
Upgrade to Rust 2024 edition, replace lazy_static and jemallocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["nlp", "chinese", "segmenation"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/messense/jieba-rs"
-edition = '2021'
+edition.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -44,7 +44,11 @@ tfidf = ["dep:ordered-float", "dep:derive_builder"]
 textrank = ["dep:ordered-float", "dep:derive_builder"]
 
 [workspace]
+resolver = "3"
 members = [".", "capi", "jieba-macros", "examples/weicheng"]
+
+[workspace.package]
+edition = "2024"
 
 [workspace.dependencies]
 c_fixed_string = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ cedarwood = { workspace = true }
 derive_builder = { workspace = true, optional = true }
 fxhash = { workspace = true }
 include-flate = { workspace = true }
-lazy_static = { workspace = true }
 ordered-float = { workspace = true, optional = true }
 phf = { workspace = true }
 regex = { workspace = true }
@@ -58,7 +57,6 @@ derive_builder = "0.20.0"
 fxhash = "0.2.1"
 include-flate = "0.3.0"
 jieba-macros = { version = "0.7.1", path = "jieba-macros" }
-lazy_static = "1.0"
 ordered-float = "5.0"
 phf = "0.12.1"
 phf_codegen = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ wasm-bindgen-test = { workspace = true }
 rayon = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
-jemallocator = "0.5.0"
+tikv-jemallocator = "0.6.0"
 
 [[bench]]
 name = "jieba_benchmark"

--- a/benches/jieba_benchmark.rs
+++ b/benches/jieba_benchmark.rs
@@ -1,17 +1,15 @@
-use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use codspeed_criterion_compat::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use jieba_rs::{Jieba, KeywordExtract, TextRank, TfIdf, TokenizeMode};
-use lazy_static::lazy_static;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::sync::LazyLock;
 
 #[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-lazy_static! {
-    static ref JIEBA: Jieba = Jieba::new();
-    static ref TFIDF_EXTRACTOR: TfIdf = TfIdf::default();
-    static ref TEXTRANK_EXTRACTOR: TextRank = TextRank::default();
-}
+static JIEBA: LazyLock<Jieba> = LazyLock::new(Jieba::new);
+static TFIDF_EXTRACTOR: LazyLock<TfIdf> = LazyLock::new(TfIdf::default);
+static TEXTRANK_EXTRACTOR: LazyLock<TextRank> = LazyLock::new(TextRank::default);
 static SENTENCE: &str = "我是拖拉机学院手扶拖拉机专业的。不用多久，我就会升职加薪，当上CEO，走上人生巅峰。";
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/jieba_benchmark.rs
+++ b/benches/jieba_benchmark.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 #[cfg(unix)]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 static JIEBA: LazyLock<Jieba> = LazyLock::new(Jieba::new);
 static TFIDF_EXTRACTOR: LazyLock<TfIdf> = LazyLock::new(TfIdf::default);

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jieba-capi"
 version = "0.1.0"
 authors = ["messense <messense@icloud.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 jieba-rs = { version = "0.7.0", path = "../", features = ["textrank", "tfidf"] }

--- a/examples/weicheng/Cargo.toml
+++ b/examples/weicheng/Cargo.toml
@@ -8,4 +8,4 @@ edition.workspace = true
 jieba-rs = { path = "../.." }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = "0.5.0"
+tikv-jemallocator = "0.6.0"

--- a/examples/weicheng/Cargo.toml
+++ b/examples/weicheng/Cargo.toml
@@ -2,7 +2,7 @@
 name = "weicheng"
 version = "0.1.0"
 authors = ["messense <messense@icloud.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 jieba-rs = { path = "../.." }

--- a/examples/weicheng/src/main.rs
+++ b/examples/weicheng/src/main.rs
@@ -3,7 +3,7 @@ use std::time;
 
 #[cfg(unix)]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 static WEICHENG_TXT: &str = include_str!("weicheng.txt");
 

--- a/jieba-macros/Cargo.toml
+++ b/jieba-macros/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["nlp", "chinese", "segmenation"]
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/messense/jieba-rs"
-edition = "2021"
+edition.workspace = true
 
 [lib]
 proc-macro = true

--- a/src/hmm.rs
+++ b/src/hmm.rs
@@ -218,7 +218,7 @@ pub fn cut<'a>(sentence: &'a str, words: &mut Vec<&'a str>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{cut, viterbi, HmmContext};
+    use super::{HmmContext, cut, viterbi};
 
     #[test]
     #[allow(non_snake_case)]
@@ -231,7 +231,9 @@ mod tests {
         viterbi(sentence, &mut hmm_context);
         assert_eq!(
             hmm_context.best_path,
-            vec![Begin, End, Begin, End, Begin, Middle, End, Begin, End, Begin, Middle, End, Begin, End, Single]
+            vec![
+                Begin, End, Begin, End, Begin, Middle, End, Begin, End, Begin, Middle, End, Begin, End, Single
+            ]
         );
     }
 

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -1,27 +1,24 @@
-use derive_builder::Builder;
-use lazy_static::lazy_static;
-use std::collections::BTreeSet;
-
 use crate::Jieba;
+use derive_builder::Builder;
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
 
 #[cfg(feature = "textrank")]
 pub mod textrank;
 #[cfg(feature = "tfidf")]
 pub mod tfidf;
 
-lazy_static! {
-    pub static ref DEFAULT_STOP_WORDS: BTreeSet<String> = {
-        BTreeSet::from_iter(
-            [
-                "the", "of", "is", "and", "to", "in", "that", "we", "for", "an", "are", "by", "be", "as", "on", "with",
-                "can", "if", "from", "which", "you", "it", "this", "then", "at", "have", "all", "not", "one", "has",
-                "or", "that",
-            ]
-            .into_iter()
-            .map(|s| s.to_string()),
-        )
-    };
-}
+pub static DEFAULT_STOP_WORDS: LazyLock<BTreeSet<String>> = LazyLock::new(|| {
+    BTreeSet::from_iter(
+        [
+            "the", "of", "is", "and", "to", "in", "that", "we", "for", "an", "are", "by", "be", "as", "on", "with",
+            "can", "if", "from", "which", "you", "it", "this", "then", "at", "have", "all", "not", "one", "has", "or",
+            "that",
+        ]
+        .into_iter()
+        .map(|s| s.to_string()),
+    )
+});
 
 /// Keyword with weight
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use crate::keywords::textrank::TextRank;
 #[cfg(feature = "tfidf")]
 pub use crate::keywords::tfidf::TfIdf;
 #[cfg(any(feature = "tfidf", feature = "textrank"))]
-pub use crate::keywords::{Keyword, KeywordExtract, KeywordExtractConfig, DEFAULT_STOP_WORDS};
+pub use crate::keywords::{DEFAULT_STOP_WORDS, Keyword, KeywordExtract, KeywordExtractConfig};
 
 mod errors;
 mod hmm;
@@ -869,7 +869,7 @@ impl Jieba {
 
 #[cfg(test)]
 mod tests {
-    use super::{Jieba, SplitMatches, SplitState, Tag, Token, TokenizeMode, RE_HAN_DEFAULT};
+    use super::{Jieba, RE_HAN_DEFAULT, SplitMatches, SplitState, Tag, Token, TokenizeMode};
     use std::io::BufReader;
 
     #[test]


### PR DESCRIPTION
1. upgrade to Rust 2024 edition
2. Rust 2024 corresponds to Rust version 1.85. In the standard library, there is [std::sync::LazyLock](https://rust-lang.github.io/rfcs/2788-standard-lazy-types.html?highlight=once_cell#), which is an alternative to `lazy_static`, and its main code comes from `once_cell`. Both `once_cell` and `lazy_static` have entered the maintenance stage. Using `std::sync::LazyLock` from the standard library is a good choice
3. jemallocator is no longer maintained. Currently, in the Rust ecosystem, the fork version of tikv is mainly used. It should be migrated to tikv_jemallocator