### PR TITLE
refactor!: inline KeywordExtractConfigBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ jieba-macros = { version = "0.8.0", path = "jieba-macros" }
 c_fixed_string = { version = "0.2" }
 cedarwood = { version = "0.4" }
 codspeed-criterion-compat = { version = "3.0.4" }
-derive_builder = { version = "0.20.0" }
 fxhash = { version = "0.2.1" }
 include-flate = { version = "0.3.0" }
 ordered-float = { version = "5.0" }

--- a/jieba-macros/src/lib.rs
+++ b/jieba-macros/src/lib.rs
@@ -33,7 +33,7 @@ pub fn generate_hmm_data(_input: TokenStream) -> TokenStream {
     // Emission probabilities
     for (i, line) in lines.filter(|x| !x.starts_with('#')).enumerate() {
         output.push_str("#[allow(clippy::style)]\n");
-        output.push_str(&format!("pub static EMIT_PROB_{}: phf::Map<&'static str, f64> = ", i));
+        output.push_str(&format!("pub static EMIT_PROB_{i}: phf::Map<&'static str, f64> = "));
 
         let mut map = phf_codegen::Map::new();
         for word_prob in line.split(',') {

--- a/jieba/Cargo.toml
+++ b/jieba/Cargo.toml
@@ -17,13 +17,12 @@ all-features = true
 [features]
 default = ["default-dict"]
 default-dict = []
-tfidf = ["dep:ordered-float", "dep:derive_builder"]
-textrank = ["dep:ordered-float", "dep:derive_builder"]
+tfidf = ["dep:ordered-float"]
+textrank = ["dep:ordered-float"]
 
 [dependencies]
 jieba-macros = { workspace = true }
 cedarwood = { workspace = true }
-derive_builder = { workspace = true, optional = true }
 fxhash = { workspace = true }
 include-flate = { workspace = true }
 ordered-float = { workspace = true, optional = true }

--- a/jieba/benches/jieba_benchmark.rs
+++ b/jieba/benches/jieba_benchmark.rs
@@ -64,14 +64,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("single_thread", |b| {
         b.iter(|| {
             for _ in 0..repeat {
-                let _words = JIEBA.cut(black_box(&SENTENCE), true);
+                let _words = JIEBA.cut(black_box(SENTENCE), true);
             }
         })
     });
     group.bench_function("multi_thread", |b| {
         b.iter(|| {
             (0..repeat).into_par_iter().for_each(|_| {
-                let _words = JIEBA.cut(black_box(&SENTENCE), true);
+                let _words = JIEBA.cut(black_box(SENTENCE), true);
             });
         })
     });

--- a/jieba/src/errors.rs
+++ b/jieba/src/errors.rs
@@ -19,7 +19,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Io(ref err) => err.fmt(f),
-            Error::InvalidDictEntry(ref err) => write!(f, "invalid dictionary entry: {}", err),
+            Error::InvalidDictEntry(ref err) => write!(f, "invalid dictionary entry: {err}"),
         }
     }
 }

--- a/jieba/src/keywords/mod.rs
+++ b/jieba/src/keywords/mod.rs
@@ -1,5 +1,5 @@
 use crate::Jieba;
-use derive_builder::Builder;
+
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
@@ -13,76 +13,75 @@ pub static DEFAULT_STOP_WORDS: LazyLock<BTreeSet<String>> = LazyLock::new(|| {
         [
             "the", "of", "is", "and", "to", "in", "that", "we", "for", "an", "are", "by", "be", "as", "on", "with",
             "can", "if", "from", "which", "you", "it", "this", "then", "at", "have", "all", "not", "one", "has", "or",
-            "that",
         ]
         .into_iter()
-        .map(|s| s.to_string()),
+        .map(ToString::to_string),
     )
 });
 
-/// Keyword with weight
+/// Keyword with weight.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Keyword {
     pub keyword: String,
     pub weight: f64,
 }
 
-/// Creates a KeywordExtractConfig state that contains filter criteria as
-/// well as segmentation configuration for use by keyword extraction
-/// implementations.
+/// Creates a KeywordExtractConfig state that contains filter criteria as well as segmentation
+/// configuration for use by keyword extraction implementations.
 ///
-/// Use KeywordExtractConfigBuilder to change the defaults.
+/// Use [`KeywordExtractConfigBuilder`] to change the defaults.
 ///
 /// # Examples
+///
 /// ```
-///    use jieba_rs::KeywordExtractConfig;
+/// use jieba_rs::KeywordExtractConfig;
 ///
-///    let mut config = KeywordExtractConfig::default();
-///    assert!(config.stop_words().contains("the"));
-///    assert!(!config.stop_words().contains("FakeWord"));
-///    assert!(!config.use_hmm());
-///    assert_eq!(2, config.min_keyword_length());
+/// let mut config = KeywordExtractConfig::default();
+/// assert!(config.stop_words().contains("the"));
+/// assert!(!config.stop_words().contains("FakeWord"));
+/// assert!(!config.use_hmm());
+/// assert_eq!(2, config.min_keyword_length());
 ///
-///    let built_default = KeywordExtractConfig::builder().build().unwrap();
-///    assert_eq!(config, built_default);
+/// let built_default = KeywordExtractConfig::builder().build();
+/// assert_eq!(config, built_default);
 ///
-///    let changed = KeywordExtractConfig::builder()
-///        .add_stop_word("FakeWord".to_string())
-///        .remove_stop_word("the")
-///        .use_hmm(true)
-///        .min_keyword_length(10)
-///        .build().unwrap();
+/// let changed = KeywordExtractConfig::builder()
+///     .add_stop_word("FakeWord".to_string())
+///     .remove_stop_word("the")
+///     .use_hmm(true)
+///     .min_keyword_length(10)
+///     .build();
 ///
-///    assert!(!changed.stop_words().contains("the"));
-///    assert!(changed.stop_words().contains("FakeWord"));
-///    assert!(changed.use_hmm());
-///    assert_eq!(10, changed.min_keyword_length());
+/// assert!(!changed.stop_words().contains("the"));
+/// assert!(changed.stop_words().contains("FakeWord"));
+/// assert!(changed.use_hmm());
+/// assert_eq!(10, changed.min_keyword_length());
 /// ```
-#[derive(Builder, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeywordExtractConfig {
-    #[builder(default = "self.default_stop_words()?", setter(custom))]
     stop_words: BTreeSet<String>,
-
-    #[builder(default = "2")]
-    #[doc = r"Any segments less than this length will not be considered a Keyword"]
     min_keyword_length: usize,
-
-    #[builder(default = "false")]
-    #[doc = r"If true, fall back to hmm model if segment cannot be found in the dictionary"]
     use_hmm: bool,
 }
 
+impl Default for KeywordExtractConfig {
+    fn default() -> KeywordExtractConfig {
+        KeywordExtractConfig::builder().build()
+    }
+}
+
 impl KeywordExtractConfig {
+    /// Creates a new [`KeywordExtractConfigBuilder`] with default values.
     pub fn builder() -> KeywordExtractConfigBuilder {
         KeywordExtractConfigBuilder::default()
     }
 
-    /// Get current set of stop words.
+    /// Gets the current set of stop words.
     pub fn stop_words(&self) -> &BTreeSet<String> {
         &self.stop_words
     }
 
-    /// True if hmm is used during segmentation in `extract_tags`.
+    /// Returns whether HMM is used during segmentation in `extract_tags`.
     pub fn use_hmm(&self) -> bool {
         self.use_hmm
     }
@@ -93,119 +92,146 @@ impl KeywordExtractConfig {
     }
 
     #[inline]
-    pub(crate) fn filter(&self, s: &str) -> bool {
+    pub(crate) fn is_keyword(&self, s: &str) -> bool {
         s.chars().count() >= self.min_keyword_length() && !self.stop_words.contains(&s.to_lowercase())
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct KeywordExtractConfigBuilder {
+    stop_words: BTreeSet<String>,
+    min_keyword_length: usize,
+    use_hmm: bool,
+}
+
+impl Default for KeywordExtractConfigBuilder {
+    fn default() -> Self {
+        KeywordExtractConfigBuilder {
+            stop_words: DEFAULT_STOP_WORDS.clone(),
+            min_keyword_length: 2,
+            use_hmm: false,
+        }
+    }
+}
+
 impl KeywordExtractConfigBuilder {
-    fn default_stop_words(&self) -> Result<BTreeSet<String>, KeywordExtractConfigBuilderError> {
-        Ok(DEFAULT_STOP_WORDS.clone())
+    /// Builds the [`KeywordExtractConfig`] with the current configuration.
+    pub fn build(self) -> KeywordExtractConfig {
+        KeywordExtractConfig {
+            stop_words: self.stop_words,
+            min_keyword_length: self.min_keyword_length,
+            use_hmm: self.use_hmm,
+        }
+    }
+
+    /// If set, when segment cannot be found in the dictionary, fall back to HMM model.
+    pub fn use_hmm(mut self, yes: bool) -> Self {
+        self.use_hmm = yes;
+        self
+    }
+
+    /// Sets the length that any segments less than it will not be considered as a keyword.
+    pub fn min_keyword_length(mut self, length: usize) -> Self {
+        self.min_keyword_length = length;
+        self
     }
 
     /// Add a new stop word.
     ///
     /// # Examples
+    ///
     /// ```
-    ///    use jieba_rs::KeywordExtractConfig;
-    ///    use std::collections::BTreeSet;
+    /// use jieba_rs::KeywordExtractConfig;
+    /// use std::collections::BTreeSet;
     ///
-    ///    let populates_default = KeywordExtractConfig::builder()
-    ///        .add_stop_word("FakeWord".to_string())
-    ///        .build().unwrap();
+    /// let populates_default = KeywordExtractConfig::builder()
+    ///     .add_stop_word("FakeWord")
+    ///     .build();
     ///
-    ///    assert!(populates_default.stop_words().contains("the"));
-    ///    assert!(populates_default.stop_words().contains("FakeWord"));
+    /// assert!(populates_default.stop_words().contains("the"));
+    /// assert!(populates_default.stop_words().contains("FakeWord"));
     ///
-    ///    let multiple_adds_stack = KeywordExtractConfig::builder()
-    ///        .add_stop_word("FakeWord".to_string())
-    ///        .add_stop_word("MoarFakeWord".to_string())
-    ///        .build().unwrap();
+    /// let multiple_adds_stack = KeywordExtractConfig::builder()
+    ///     .add_stop_word("FakeWord")
+    ///     .add_stop_word("MoarFakeWord")
+    ///     .build();
     ///
-    ///    assert!(multiple_adds_stack.stop_words().contains("the"));
-    ///    assert!(multiple_adds_stack.stop_words().contains("FakeWord"));
-    ///    assert!(multiple_adds_stack.stop_words().contains("MoarFakeWord"));
+    /// assert!(multiple_adds_stack.stop_words().contains("the"));
+    /// assert!(multiple_adds_stack.stop_words().contains("FakeWord"));
+    /// assert!(multiple_adds_stack.stop_words().contains("MoarFakeWord"));
     ///
-    ///    let no_default_if_set = KeywordExtractConfig::builder()
-    ///        .set_stop_words(BTreeSet::from(["boo".to_string()]))
-    ///        .add_stop_word("FakeWord".to_string())
-    ///        .build().unwrap();
+    /// let no_default_if_set = KeywordExtractConfig::builder()
+    ///     .set_stop_words(BTreeSet::from(["boo".to_string()]))
+    ///     .add_stop_word("FakeWord".to_string())
+    ///     .build();
     ///
-    ///    assert!(!no_default_if_set.stop_words().contains("the"));
-    ///    assert!(no_default_if_set.stop_words().contains("boo"));
-    ///    assert!(no_default_if_set.stop_words().contains("FakeWord"));
+    /// assert!(!no_default_if_set.stop_words().contains("the"));
+    /// assert!(no_default_if_set.stop_words().contains("boo"));
+    /// assert!(no_default_if_set.stop_words().contains("FakeWord"));
     /// ```
-    pub fn add_stop_word(&mut self, word: String) -> &mut Self {
-        if self.stop_words.is_none() {
-            self.stop_words = Some(self.default_stop_words().unwrap());
-        }
-        self.stop_words.as_mut().unwrap().insert(word);
+    pub fn add_stop_word(mut self, word: impl Into<String>) -> Self {
+        self.stop_words.insert(word.into());
         self
     }
 
-    /// Remove an existing stop word.
+    /// Remove a stop word.
+    ///
+    /// If the word is not in the set, this is no op.
     ///
     /// # Examples
+    ///
     /// ```
-    ///    use jieba_rs::KeywordExtractConfig;
-    ///    use std::collections::BTreeSet;
+    /// use jieba_rs::KeywordExtractConfig;
+    /// use std::collections::BTreeSet;
     ///
-    ///    let populates_default = KeywordExtractConfig::builder()
-    ///        .remove_stop_word("the")
-    ///        .build().unwrap();
+    /// let populates_default = KeywordExtractConfig::builder()
+    ///     .remove_stop_word("the")
+    ///     .build();
     ///
-    ///    assert!(!populates_default.stop_words().contains("the"));
-    ///    assert!(populates_default.stop_words().contains("of"));
+    /// assert!(!populates_default.stop_words().contains("the"));
+    /// assert!(populates_default.stop_words().contains("of"));
     ///
-    ///    let no_default_if_set = KeywordExtractConfig::builder()
-    ///        .set_stop_words(BTreeSet::from(["boo".to_string()]))
-    ///         // Removing non-existant word is okay.
-    ///        .remove_stop_word("the".to_string())
-    ///        .build().unwrap();
+    /// let no_default_if_set = KeywordExtractConfig::builder()
+    ///     .set_stop_words(BTreeSet::from(["boo".to_string()]))
+    ///     // removing non-existent word is okay
+    ///     .remove_stop_word("the")
+    ///     .build();
     ///
-    ///    assert!(!no_default_if_set.stop_words().contains("the"));
-    ///    assert!(!no_default_if_set.stop_words().contains("of"));
-    ///    assert!(no_default_if_set.stop_words().contains("boo"));
+    /// assert!(!no_default_if_set.stop_words().contains("the"));
+    /// assert!(!no_default_if_set.stop_words().contains("of"));
+    /// assert!(no_default_if_set.stop_words().contains("boo"));
     /// ```
-    pub fn remove_stop_word(&mut self, word: impl AsRef<str>) -> &mut Self {
-        if self.stop_words.is_none() {
-            self.stop_words = Some(self.default_stop_words().unwrap());
-        }
-        self.stop_words.as_mut().unwrap().remove(word.as_ref());
+    pub fn remove_stop_word(mut self, word: impl AsRef<str>) -> Self {
+        self.stop_words.remove(word.as_ref());
         self
     }
 
     /// Replace all stop words with new stop words set.
     ///
     /// # Examples
+    ///
     /// ```
-    ///    use jieba_rs::KeywordExtractConfig;
-    ///    use std::collections::BTreeSet;
+    /// use jieba_rs::KeywordExtractConfig;
+    /// use std::collections::BTreeSet;
     ///
-    ///    let no_default_if_set = KeywordExtractConfig::builder()
-    ///        .set_stop_words(BTreeSet::from(["boo".to_string()]))
-    ///        .build().unwrap();
+    /// let no_default_if_set = KeywordExtractConfig::builder()
+    ///     .set_stop_words(BTreeSet::from(["boo".to_string()]))
+    ///     .build();
     ///
-    ///    assert!(!no_default_if_set.stop_words().contains("the"));
-    ///    assert!(no_default_if_set.stop_words().contains("boo"));
+    /// assert!(!no_default_if_set.stop_words().contains("the"));
+    /// assert!(no_default_if_set.stop_words().contains("boo"));
     ///
-    ///    let overwrites = KeywordExtractConfig::builder()
-    ///        .add_stop_word("FakeWord".to_string())
-    ///        .set_stop_words(BTreeSet::from(["boo".to_string()]))
-    ///        .build().unwrap();
+    /// let overwrites = KeywordExtractConfig::builder()
+    ///     .add_stop_word("FakeWord".to_string())
+    ///     .set_stop_words(BTreeSet::from(["boo".to_string()]))
+    ///     .build();
     ///
-    ///    assert!(!no_default_if_set.stop_words().contains("FakeWord"));
-    ///    assert!(no_default_if_set.stop_words().contains("boo"));
+    /// assert!(!no_default_if_set.stop_words().contains("FakeWord"));
+    /// assert!(no_default_if_set.stop_words().contains("boo"));
     /// ```
-    pub fn set_stop_words(&mut self, stop_words: BTreeSet<String>) -> &mut Self {
-        self.stop_words = Some(stop_words);
+    pub fn set_stop_words(mut self, stop_words: BTreeSet<String>) -> Self {
+        self.stop_words = stop_words;
         self
-    }
-}
-
-impl Default for KeywordExtractConfig {
-    fn default() -> KeywordExtractConfig {
-        KeywordExtractConfigBuilder::default().build().unwrap()
     }
 }
 

--- a/jieba/src/keywords/textrank.rs
+++ b/jieba/src/keywords/textrank.rs
@@ -68,7 +68,7 @@ impl StateDiagram {
     }
 }
 
-/// Text rank keywords extraction.
+/// Text rank keywords' extraction.
 ///
 /// Requires `textrank` feature to be enabled.
 #[derive(Debug)]
@@ -84,15 +84,15 @@ impl TextRank {
     ///
     /// New instance with custom stop words. Also uses hmm for unknown words
     /// during segmentation.
-    /// ```
-    ///    use std::collections::BTreeSet;
-    ///    use jieba_rs::{TextRank, KeywordExtractConfig};
     ///
-    ///    let stop_words : BTreeSet<String> =
-    ///        BTreeSet::from(["a", "the", "of"].map(|s| s.to_string()));
-    ///    TextRank::new(
-    ///        5,
-    ///        KeywordExtractConfig::default());
+    /// ```
+    /// use std::collections::BTreeSet;
+    /// use jieba_rs::{TextRank, KeywordExtractConfig};
+    ///
+    /// let stop_words : BTreeSet<String> =
+    ///     BTreeSet::from(["a", "the", "of"].map(|s| s.to_string()));
+    ///
+    /// TextRank::new(5, KeywordExtractConfig::default());
     /// ```
     pub fn new(span: usize, config: KeywordExtractConfig) -> Self {
         TextRank { span, config }
@@ -102,7 +102,7 @@ impl TextRank {
 impl Default for TextRank {
     /// Creates TextRank with 5 Unicode Scalar Value spans
     fn default() -> Self {
-        TextRank::new(5, KeywordExtractConfigBuilder::default().build().unwrap())
+        TextRank::new(5, KeywordExtractConfigBuilder::default().build())
     }
 }
 
@@ -115,31 +115,31 @@ impl KeywordExtract for TextRank {
     /// # Examples
     ///
     /// ```
-    ///    use jieba_rs::{Jieba, KeywordExtract, TextRank};
+    /// use jieba_rs::{Jieba, KeywordExtract, TextRank};
     ///
-    ///    let jieba = Jieba::new();
-    ///    let keyword_extractor = TextRank::default();
-    ///    let mut top_k = keyword_extractor.extract_keywords(
-    ///        &jieba,
-    ///        "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
-    ///        6,
-    ///        vec![String::from("ns"), String::from("n"), String::from("vn"), String::from("v")],
-    ///    );
-    ///    assert_eq!(
-    ///        top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
-    ///        vec!["吉林", "欧亚", "置业", "实现", "收入", "子公司"]
-    ///    );
+    /// let jieba = Jieba::new();
+    /// let keyword_extractor = TextRank::default();
+    /// let mut top_k = keyword_extractor.extract_keywords(
+    ///     &jieba,
+    ///     "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
+    ///     6,
+    ///     vec![String::from("ns"), String::from("n"), String::from("vn"), String::from("v")],
+    /// );
+    /// assert_eq!(
+    ///     top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
+    ///     vec!["吉林", "欧亚", "置业", "实现", "收入", "子公司"],
+    /// );
     ///
-    ///    top_k = keyword_extractor.extract_keywords(
-    ///        &jieba,
-    ///        "It is nice weather in New York City. and今天纽约的天气真好啊，and京华大酒店的张尧经理吃了一只北京烤鸭。and后天纽约的天气不好，and昨天纽约的天气也不好，and北京烤鸭真好吃",
-    ///        3,
-    ///        vec![],
-    ///    );
-    ///    assert_eq!(
-    ///        top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
-    ///        vec!["纽约", "天气", "不好"]
-    ///    );
+    /// top_k = keyword_extractor.extract_keywords(
+    ///     &jieba,
+    ///     "It is nice weather in New York City. and今天纽约的天气真好啊，and京华大酒店的张尧经理吃了一只北京烤鸭。and后天纽约的天气不好，and昨天纽约的天气也不好，and北京烤鸭真好吃",
+    ///     3,
+    ///     vec![],
+    /// );
+    /// assert_eq!(
+    ///     top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
+    ///     vec!["纽约", "天气", "不好"],
+    /// );
     /// ```
     fn extract_keywords(&self, jieba: &Jieba, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword> {
         let tags = jieba.tag(sentence, self.config.use_hmm());
@@ -169,7 +169,7 @@ impl KeywordExtract for TextRank {
                 continue;
             }
 
-            if !self.config.filter(t.word) {
+            if !self.config.is_keyword(t.word) {
                 continue;
             }
 
@@ -182,7 +182,7 @@ impl KeywordExtract for TextRank {
                     continue;
                 }
 
-                if !self.config.filter(tags[j].word) {
+                if !self.config.is_keyword(tags[j].word) {
                     continue;
                 }
 
@@ -251,6 +251,7 @@ impl PartialOrd for HeapNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_init_state_diagram() {
         let diagram = StateDiagram::new(10);

--- a/jieba/src/keywords/tfidf.rs
+++ b/jieba/src/keywords/tfidf.rs
@@ -81,39 +81,36 @@ impl TfIdf {
         instance
     }
 
-    /// Merges entires from `dict` into the `idf_dict`.
+    /// Merges entries from `dict` into the `idf_dict`.
     ///
     /// ```
-    ///    use jieba_rs::{Jieba, KeywordExtract, Keyword, KeywordExtractConfig,
-    ///        TfIdf};
+    /// use jieba_rs::{Jieba, KeywordExtract, Keyword, KeywordExtractConfig, TfIdf};
     ///
-    ///    let jieba = Jieba::default();
-    ///    let mut init_idf = "生化学 13.900677652\n";
+    /// let jieba = Jieba::default();
+    /// let mut init_idf = "生化学 13.900677652\n";
     ///
-    ///    let mut tfidf = TfIdf::new(
-    ///        Some(&mut init_idf.as_bytes()),
-    ///        KeywordExtractConfig::default());
-    ///    let top_k = tfidf.extract_keywords(&jieba, "生化学不是光化学的,", 3, vec![]);
-    ///    assert_eq!(
-    ///        top_k,
-    ///        vec![
-    ///            Keyword { keyword: "不是".to_string(), weight: 4.6335592173333335 },
-    ///            Keyword { keyword: "光化学".to_string(), weight: 4.6335592173333335 },
-    ///            Keyword { keyword: "生化学".to_string(), weight: 4.6335592173333335 }
-    ///        ]
-    ///    );
+    /// let mut tfidf = TfIdf::new(Some(&mut init_idf.as_bytes()), KeywordExtractConfig::default());
+    /// let top_k = tfidf.extract_keywords(&jieba, "生化学不是光化学的,", 3, vec![]);
+    /// assert_eq!(
+    ///     top_k,
+    ///     vec![
+    ///         Keyword { keyword: "不是".to_string(), weight: 4.6335592173333335 },
+    ///         Keyword { keyword: "光化学".to_string(), weight: 4.6335592173333335 },
+    ///         Keyword { keyword: "生化学".to_string(), weight: 4.6335592173333335 }
+    ///     ],
+    /// );
     ///
-    ///    let mut init_idf = "光化学 99.123456789\n";
-    ///    tfidf.load_dict(&mut init_idf.as_bytes());
-    ///    let new_top_k = tfidf.extract_keywords(&jieba, "生化学不是光化学的,", 3, vec![]);
-    ///    assert_eq!(
-    ///        new_top_k,
-    ///        vec![
-    ///            Keyword { keyword: "不是".to_string(), weight: 33.041152263 },
-    ///            Keyword { keyword: "光化学".to_string(), weight: 33.041152263 },
-    ///            Keyword { keyword: "生化学".to_string(), weight: 4.6335592173333335 }
-    ///        ]
-    ///    );
+    /// let mut init_idf = "光化学 99.123456789\n";
+    /// tfidf.load_dict(&mut init_idf.as_bytes()).unwrap();
+    /// let new_top_k = tfidf.extract_keywords(&jieba, "生化学不是光化学的,", 3, vec![]);
+    /// assert_eq!(
+    ///     new_top_k,
+    ///     vec![
+    ///         Keyword { keyword: "不是".to_string(), weight: 33.041152263 },
+    ///         Keyword { keyword: "光化学".to_string(), weight: 33.041152263 },
+    ///         Keyword { keyword: "生化学".to_string(), weight: 4.6335592173333335 }
+    ///     ]
+    /// );
     /// ```
     pub fn load_dict(&mut self, dict: &mut impl BufRead) -> io::Result<()> {
         let mut buf = String::new();
@@ -160,10 +157,7 @@ impl Default for TfIdf {
     /// 2 Unicode Scalar Value minimum for keywords, and no hmm in segmentation.
     fn default() -> Self {
         let mut default_dict = BufReader::new(DEFAULT_IDF.as_bytes());
-        TfIdf::new(
-            Some(&mut default_dict),
-            KeywordExtractConfigBuilder::default().build().unwrap(),
-        )
+        TfIdf::new(Some(&mut default_dict), KeywordExtractConfigBuilder::default().build())
     }
 }
 
@@ -174,43 +168,44 @@ impl KeywordExtract for TfIdf {
     /// speech are considered.
     ///
     /// # Examples
+    ///
     /// ```
-    ///    use jieba_rs::{Jieba, KeywordExtract, TfIdf};
+    /// use jieba_rs::{Jieba, KeywordExtract, TfIdf};
     ///
-    ///    let jieba = Jieba::new();
-    ///    let keyword_extractor = TfIdf::default();
-    ///    let mut top_k = keyword_extractor.extract_keywords(
-    ///        &jieba,
-    ///        "今天纽约的天气真好啊，京华大酒店的张尧经理吃了一只北京烤鸭。后天纽约的天气不好，昨天纽约的天气也不好，北京烤鸭真好吃",
-    ///        3,
-    ///        vec![],
-    ///    );
-    ///    assert_eq!(
-    ///        top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
-    ///        vec!["北京烤鸭", "纽约", "天气"]
-    ///    );
+    /// let jieba = Jieba::new();
+    /// let keyword_extractor = TfIdf::default();
+    /// let mut top_k = keyword_extractor.extract_keywords(
+    ///     &jieba,
+    ///     "今天纽约的天气真好啊，京华大酒店的张尧经理吃了一只北京烤鸭。后天纽约的天气不好，昨天纽约的天气也不好，北京烤鸭真好吃",
+    ///     3,
+    ///     vec![],
+    /// );
+    /// assert_eq!(
+    ///     top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
+    ///     vec!["北京烤鸭", "纽约", "天气"],
+    /// );
     ///
-    ///    top_k = keyword_extractor.extract_keywords(
-    ///        &jieba,
-    ///        "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
-    ///        5,
-    ///        vec![],
-    ///    );
-    ///    assert_eq!(
-    ///        top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
-    ///        vec!["欧亚", "吉林", "置业", "万元", "增资"]
-    ///    );
+    /// top_k = keyword_extractor.extract_keywords(
+    ///     &jieba,
+    ///     "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
+    ///     5,
+    ///     vec![],
+    /// );
+    /// assert_eq!(
+    ///     top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
+    ///     vec!["欧亚", "吉林", "置业", "万元", "增资"],
+    /// );
     ///
-    ///    top_k = keyword_extractor.extract_keywords(
-    ///        &jieba,
-    ///        "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
-    ///        5,
-    ///        vec![String::from("ns"), String::from("n"), String::from("vn"), String::from("v")],
-    ///    );
-    ///    assert_eq!(
-    ///        top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
-    ///        vec!["欧亚", "吉林", "置业", "增资", "实现"]
-    ///    );
+    /// top_k = keyword_extractor.extract_keywords(
+    ///     &jieba,
+    ///     "此外，公司拟对全资子公司吉林欧亚置业有限公司增资4.3亿元，增资后，吉林欧亚置业注册资本由7000万元增加到5亿元。吉林欧亚置业主要经营范围为房地产开发及百货零售等业务。目前在建吉林欧亚城市商业综合体项目。2013年，实现营业收入0万元，实现净利润-139.13万元。",
+    ///     5,
+    ///     vec![String::from("ns"), String::from("n"), String::from("vn"), String::from("v")],
+    /// );
+    /// assert_eq!(
+    ///     top_k.iter().map(|x| &x.keyword).collect::<Vec<&String>>(),
+    ///     vec!["欧亚", "吉林", "置业", "增资", "实现"]
+    /// );
     /// ```
     fn extract_keywords(&self, jieba: &Jieba, sentence: &str, top_k: usize, allowed_pos: Vec<String>) -> Vec<Keyword> {
         let tags = jieba.tag(sentence, self.config.use_hmm());
@@ -226,7 +221,7 @@ impl KeywordExtract for TfIdf {
                 continue;
             }
 
-            if !self.config.filter(t.word) {
+            if !self.config.is_keyword(t.word) {
                 continue;
             }
 

--- a/jieba/src/lib.rs
+++ b/jieba/src/lib.rs
@@ -402,8 +402,7 @@ impl Jieba {
                         .map(|x| {
                             x.parse::<usize>().map_err(|e| {
                                 Error::InvalidDictEntry(format!(
-                                    "line {} `{}` frequency {} is not a valid integer: {}",
-                                    line_no, buf, x, e
+                                    "line {line_no} `{buf}` frequency {x} is not a valid integer: {e}"
                                 ))
                             })
                         })
@@ -1016,7 +1015,7 @@ mod tests {
 
         let words = jieba.cut_for_search("小明硕士毕业于中国科学院计算所，后在日本京都大学深造", true);
 
-        // The python implementation silently filtered "，". but we includes it here in the output
+        // The python implementation silently filtered "，". but we include it here in the output
         // to let the library user to decide their own filtering strategy
         assert_eq!(
             words,


### PR DESCRIPTION
This is a breaking change while existing experience remains almost the same.

`derive_builder` is an unnecessary indirection while inline the impl of `KeywordExtractConfigBuilder` keep code clear and reduce some unnecessary unwrap.