### PR TITLE
feat: reduce memory footprint via Box<str>

### DIFF
--- a/jieba/src/lib.rs
+++ b/jieba/src/lib.rs
@@ -211,12 +211,12 @@ pub struct Tag<'a> {
 #[derive(Debug, Clone)]
 struct Record {
     freq: usize,
-    tag: String,
+    tag: Box<str>,
 }
 
 impl Record {
     #[inline(always)]
-    fn new(freq: usize, tag: String) -> Self {
+    fn new(freq: usize, tag: Box<str>) -> Self {
         Self { freq, tag }
     }
 }
@@ -349,7 +349,7 @@ impl Jieba {
             }
             None => {
                 let word_id = self.records.len() as i32;
-                self.records.push(Record::new(freq, String::from(tag)));
+                self.records.push(Record::new(freq, tag.into()));
 
                 self.cedar.update(word, word_id);
                 self.total += freq;
@@ -423,7 +423,7 @@ impl Jieba {
                         }
                         None => {
                             let word_id = self.records.len() as i32;
-                            self.records.push(Record::new(freq, String::from(tag)));
+                            self.records.push(Record::new(freq, tag.into()));
                             self.cedar.update(word, word_id);
                         }
                     };


### PR DESCRIPTION
## Problem and Solution

Since `tag` is a readonly field in `Record`, we could optimize `String` into `Box<str>` to reduce memory footprint

The `Keyword` struct could also be optimized in a similar way, but it's public so I'll leave it as it is.

### before

```rust
#[derive(Debug, Clone)]
struct Record {
    freq: usize,
    tag: String,
}
```

### after 


```rust
#[derive(Debug, Clone)]
struct Record {
    freq: usize,
    tag: Box<str>,
}
```

## Benchmark

I had measure the memory footprint via DHAT's profiler with the following code

```rust
#!/usr/bin/env rust-script
//! ```cargo
//! [dependencies]
//! jieba-rs = { git = "https://github.com/hsqStephenZhang/jieba-rs.git", branch = "feat/mem_opt" }
//! 
//! [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
//! dhat = "0.3"
//! ```

use jieba_rs::Jieba;

#[cfg(any(target_os = "linux", target_os = "macos"))]
#[global_allocator]
static ALLOC: dhat::Alloc = dhat::Alloc;

fn main() {
    #[cfg(any(target_os = "linux", target_os = "macos"))]
    let _profiler = dhat::Profiler::new_heap();

    let _jieba = Jieba::new();
}
```

### before 

```txt
dhat: Total:     97,617,571 bytes in 349,890 blocks
dhat: At t-gmax: 46,787,718 bytes in 349,053 blocks
```

### after 

```txt
dhat: Total:     89,228,995 bytes in 349,890 blocks
dhat: At t-gmax: 42,593,414 bytes in 349,053 blocks
```

## TODO

- [ ] the argument in Record could be modified as `impl Into<Box<str>>`, but I'm not sure if it's wanted.
