### PR TITLE
chore: avoid unnecessary string usages

### DIFF
--- a/jieba/src/keywords/textrank.rs
+++ b/jieba/src/keywords/textrank.rs
@@ -149,7 +149,7 @@ impl KeywordExtract for TextRank {
             allowed_pos_set.insert(s);
         }
 
-        let mut word2id: HashMap<String, usize> =
+        let mut word2id: HashMap<&str, usize> =
             HashMap::with_capacity_and_hasher(tags.len() / 2, rustc_hash::FxBuildHasher);
         let mut unique_words = Vec::with_capacity(tags.len() / 2);
         for t in &tags {
@@ -158,8 +158,8 @@ impl KeywordExtract for TextRank {
             }
 
             if !word2id.contains_key(t.word) {
-                unique_words.push(String::from(t.word));
-                word2id.insert(String::from(t.word), unique_words.len() - 1);
+                unique_words.push(t.word);
+                word2id.insert(&t.word, unique_words.len() - 1);
             }
         }
 
@@ -216,7 +216,7 @@ impl KeywordExtract for TextRank {
         for _ in 0..top_k {
             if let Some(w) = heap.pop() {
                 res.push(Keyword {
-                    keyword: unique_words[w.word_id].clone(),
+                    keyword: unique_words[w.word_id].to_string(),
                     weight: w.rank.into_inner(),
                 });
             }

--- a/jieba/src/keywords/tfidf.rs
+++ b/jieba/src/keywords/tfidf.rs
@@ -215,7 +215,7 @@ impl KeywordExtract for TfIdf {
             allowed_pos_set.insert(s);
         }
 
-        let mut term_freq: HashMap<String, u64> = HashMap::default();
+        let mut term_freq: HashMap<&str, u64> = HashMap::default();
         for t in &tags {
             if !allowed_pos_set.is_empty() && !allowed_pos_set.contains(t.tag) {
                 continue;
@@ -225,14 +225,13 @@ impl KeywordExtract for TfIdf {
                 continue;
             }
 
-            let entry = term_freq.entry(String::from(t.word)).or_insert(0);
-            *entry += 1;
+            *term_freq.entry(t.word).or_insert(0) += 1;
         }
 
         let total: u64 = term_freq.values().sum();
         let mut heap = BinaryHeap::new();
         for (cnt, (k, tf)) in term_freq.iter().enumerate() {
-            let idf = self.idf_dict.get(k).unwrap_or(&self.median_idf);
+            let idf = self.idf_dict.get(*k).unwrap_or(&self.median_idf);
             let node = HeapNode {
                 tfidf: OrderedFloat(*tf as f64 * idf / total as f64),
                 word: k,


### PR DESCRIPTION
Optimize some `String` allocations away, will not speed up performance that much since it's not a hot path.