### PR TITLE
fix: perf not full right when text is long the dag perf

### DIFF
--- a/jieba/src/sparse_dag.rs
+++ b/jieba/src/sparse_dag.rs
@@ -2,6 +2,7 @@ pub(crate) struct StaticSparseDAG {
     array: Vec<u64>,
     /// Maps byte offset → index into `array`. Uses `usize::MAX` as sentinel for "no entry".
     start_pos: Vec<usize>,
+    touched_start_pos: Vec<usize>,
     size_hint_for_iterator: usize,
     curr_insertion_len: usize,
 }
@@ -76,6 +77,7 @@ impl StaticSparseDAG {
         StaticSparseDAG {
             array: Vec::with_capacity(capacity),
             start_pos: vec![NO_ENTRY; start_pos_len],
+            touched_start_pos: Vec::with_capacity(MIN_CAPACITY),
             size_hint_for_iterator: 0,
             curr_insertion_len: 0,
         }
@@ -87,6 +89,9 @@ impl StaticSparseDAG {
         self.curr_insertion_len = 0;
         if from >= self.start_pos.len() {
             self.start_pos.resize(from + 1, NO_ENTRY);
+        }
+        if self.start_pos[from] == NO_ENTRY {
+            self.touched_start_pos.push(from);
         }
         self.start_pos[from] = idx;
     }
@@ -125,7 +130,9 @@ impl StaticSparseDAG {
 
     pub(crate) fn clear(&mut self) {
         self.array.clear();
-        self.start_pos.fill(NO_ENTRY);
+        for from in self.touched_start_pos.drain(..) {
+            self.start_pos[from] = NO_ENTRY;
+        }
     }
 }
 
@@ -153,5 +160,27 @@ mod tests {
             let edges: Vec<usize> = dag.iter_edges(i).map(|(to, _)| to).collect();
             assert_eq!(item, &edges);
         }
+    }
+
+    #[test]
+    fn test_clear_resets_touched_offsets() {
+        let mut dag = StaticSparseDAG::with_size_hint(2);
+
+        dag.start(0);
+        dag.insert(1, 1);
+        dag.commit();
+        dag.start(3);
+        dag.insert(4, 2);
+        dag.commit();
+
+        assert_ne!(dag.start_pos[0], NO_ENTRY);
+        assert_ne!(dag.start_pos[3], NO_ENTRY);
+
+        dag.clear();
+
+        assert!(dag.array.is_empty());
+        assert!(dag.touched_start_pos.is_empty());
+        assert_eq!(dag.start_pos[0], NO_ENTRY);
+        assert_eq!(dag.start_pos[3], NO_ENTRY);
     }
 }


### PR DESCRIPTION
Hi @messense  @tisonkun 

when I just read the amazing article https://messense.me/making-jieba-rs-2-4x-faster-zh-cn 

but when I tried to upgrade it in https://github.com/jiegec/tantivy-jieba to 0.9.0 
when I ran the cargo bench after update the version to 0.9.0 
but the bench is 40 times slow ....its not right

after some dig the reason is that when text is long the not right it always re alloc


Results before this fix:

| source | short sentence x100000 | whole `weicheng.txt` | line-by-line `weicheng.txt` |
| --- | ---: | ---: | ---: |
| `jieba-rs 0.8.1` | `394.615709 ms` | `36.020167 ms` | `32.372834 ms` |
| crates.io `jieba-rs 0.9.0` | `342.159291 ms` | `1.600094625 s` | `130.526459 ms` |
| patched local change | `262.749834 ms` | `26.455667 ms` | `26.3505 ms` |

The short-sentence case did improve, which matches the article. The regression
only appears when a long text containing many small matched blocks is passed as
one string. 

## Root cause

PR #141 changed `StaticSparseDAG::start_pos` from a `HashMap<usize, usize>` to a
`Vec<usize>`. That is the righ for lookup speed but `StaticSparseDAG::clear()` then reset the full `start_pos` table:

This change tracks the offsets touched by the current DAG and resets only those
entries on clear(). It keeps the Vec lookup fast path while avoiding O(full input
length * block count) clearing behavior.

all code change is wrote by GPT5.5 and me help the analyst but I take the follow responsible for review and 
other change

not long text perf bench mark add in this patch if we want it, will follow up another patch.