### PR TITLE
perf: optimize segmentation hot paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ jieba-macros = { version = "0.10.0", path = "jieba-macros" }
 
 # Crates.io dependencies
 c_fixed_string = { version = "0.2" }
+bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 cedarwood = { version = "0.4" }
 codspeed-criterion-compat = { version = "3.0.5" }
 rustc-hash = { version = "2.1" }

--- a/jieba/Cargo.toml
+++ b/jieba/Cargo.toml
@@ -22,6 +22,7 @@ textrank = ["dep:ordered-float"]
 
 [dependencies]
 jieba-macros = { workspace = true }
+bytecount = { workspace = true }
 cedarwood = { workspace = true }
 rustc-hash = { workspace = true }
 include-flate = { workspace = true, optional = true }

--- a/jieba/src/hmm.rs
+++ b/jieba/src/hmm.rs
@@ -144,6 +144,7 @@ pub(crate) struct HmmContext {
     v: Vec<f64>,
     prev: Vec<Option<State>>,
     best_path: Vec<State>,
+    chars: Vec<(usize, char)>,
 }
 
 #[allow(non_snake_case, clippy::needless_range_loop)]
@@ -152,15 +153,17 @@ fn viterbi(sentence: &str, params: &impl HmmParams, hmm_context: &mut HmmContext
     #[allow(non_snake_case)]
     let R = states.len();
 
-    // Collect char byte offsets once, derive C from the length
-    let chars: Vec<(usize, char)> = sentence.char_indices().collect();
+    // Collect char byte offsets into reusable scratch space, derive C from the length.
+    hmm_context.chars.clear();
+    hmm_context.chars.extend(sentence.char_indices());
+    let chars = &hmm_context.chars;
     let C = chars.len();
     assert!(C > 1);
 
-    // TODO: Can code just do fill() with the default instead of clear() and resize?
     if hmm_context.prev.len() < R * C {
         hmm_context.prev.resize(R * C, None);
     }
+    hmm_context.prev[..R].fill(None);
 
     if hmm_context.v.len() < R * C {
         hmm_context.v.resize(R * C, 0.0);
@@ -214,9 +217,7 @@ fn viterbi(sentence: &str, params: &impl HmmParams, hmm_context: &mut HmmContext
         curr = p;
         t -= 1;
     }
-
-    hmm_context.prev.clear();
-    hmm_context.v.clear();
+    hmm_context.best_path.truncate(C);
 }
 
 #[allow(non_snake_case)]
@@ -230,37 +231,31 @@ fn cut_internal<'a>(
     viterbi(sentence, params, hmm_context);
     let mut begin = 0;
     let mut next_byte_offset = 0;
-    let mut i = 0;
 
-    let mut curr = sentence.char_indices().map(|x| x.0).peekable();
-    while let Some(curr_byte_offset) = curr.next() {
+    for (i, &(curr_byte_offset, _)) in hmm_context.chars.iter().enumerate() {
         let state = hmm_context.best_path[i];
         match state {
             State::Begin => begin = curr_byte_offset,
             State::End => {
                 let byte_start = begin;
-                let byte_end = *curr.peek().unwrap_or(&str_len);
+                let byte_end = hmm_context.chars.get(i + 1).map_or(str_len, |&(offset, _)| offset);
                 words.push(&sentence[byte_start..byte_end]);
                 next_byte_offset = byte_end;
             }
             State::Single => {
                 let byte_start = curr_byte_offset;
-                let byte_end = *curr.peek().unwrap_or(&str_len);
+                let byte_end = hmm_context.chars.get(i + 1).map_or(str_len, |&(offset, _)| offset);
                 words.push(&sentence[byte_start..byte_end]);
                 next_byte_offset = byte_end;
             }
             State::Middle => { /* do nothing */ }
         }
-
-        i += 1;
     }
 
     if next_byte_offset < str_len {
         let byte_start = next_byte_offset;
         words.push(&sentence[byte_start..]);
     }
-
-    hmm_context.best_path.clear();
 }
 
 #[allow(non_snake_case)]

--- a/jieba/src/lib.rs
+++ b/jieba/src/lib.rs
@@ -140,6 +140,15 @@ fn is_skip_cut_all(c: char) -> bool {
     !c.is_ascii_alphanumeric() && c != '+' && c != '#' && c != '\n'
 }
 
+#[inline]
+fn char_count(s: &str) -> usize {
+    if s.len() >= 16 {
+        bytecount::num_chars(s.as_bytes())
+    } else {
+        s.as_bytes().iter().filter(|&&b| (b as i8) >= -0x40).count()
+    }
+}
+
 /// Iterator that splits text into matched/unmatched regions by a character classifier.
 /// Matched = maximal runs where `classify(c)` is true.
 /// Unmatched = everything between matched runs.
@@ -605,7 +614,7 @@ impl Jieba {
                 } else {
                     &block[byte_start..byte_end]
                 };
-                let char_count = word.as_bytes().iter().filter(|&&b| (b as i8) >= -0x40).count();
+                let char_count = char_count(word);
                 let bs = byte_offset_in_sentence + byte_start;
                 tokens.push(Token {
                     word,
@@ -748,7 +757,7 @@ impl Jieba {
         let byte_end = byte_start + word.len();
         let start = *unicode_offset;
         // Count UTF-8 leading bytes to get char count without allocating
-        let char_count = word.as_bytes().iter().filter(|&&b| (b as i8) >= -0x40).count();
+        let char_count = char_count(word);
         *unicode_offset = start + char_count;
         Token {
             word,
@@ -839,7 +848,7 @@ impl Jieba {
                     assert!(!block.is_empty());
                     let block_unicode_start = unicode_offset;
                     // Advance unicode_offset past this block
-                    unicode_offset += block.chars().count();
+                    unicode_offset += char_count(block);
                     self.cut_all_tokens(block, base, block_unicode_start, &mut tokens);
                 }
                 SplitState::Unmatched(_) => {
@@ -901,9 +910,11 @@ impl Jieba {
         let words = self.cut(sentence, hmm);
         let mut new_words = Vec::with_capacity(words.len());
         let base = sentence.as_ptr() as usize;
+        let mut char_indices = Vec::new();
         for token in words {
             let word = token.word;
-            let char_indices: Vec<usize> = word.char_indices().map(|x| x.0).collect();
+            char_indices.clear();
+            char_indices.extend(word.char_indices().map(|x| x.0));
             let char_count = char_indices.len();
             if char_count > 2 {
                 for i in 0..char_count - 1 {


### PR DESCRIPTION
Reuse HMM scratch buffers across segments and reuse cut_for_search character-index scratch storage to reduce hot-path allocation churn.

Use bytecount with runtime-dispatch-simd for longer UTF-8 character counts, while keeping the existing small-slice counting path for short tokens.

Local benchmark ( M4 Max) highlights from the optimization pass:

- cut_for_search improved from about 1.88 us to about 1.57 us on the Criterion short sentence benchmark
- cut with HMM improved from about 1.34 us to about 1.30 us
- whole-file weicheng runs improved materially: cut 30 from about 685 ms to 586 ms, search 20 from about 644 ms to 493 ms, and tag 20 from about 837 ms to 719 ms